### PR TITLE
Floor and hand display during emulation.

### DIFF
--- a/web/components/css/hrmfiddle.css
+++ b/web/components/css/hrmfiddle.css
@@ -79,3 +79,15 @@ html, body
 .alert {
   margin: 5px;
 }
+
+#floorState, #handState {
+  float: left;
+  margin: 10px;
+}
+#floorState td, #handState {
+  border: 1px solid black;
+  width: 30px;
+  height: 30px;
+  text-align: center;
+  vertical-align: middle;
+}

--- a/web/components/js/controller.js
+++ b/web/components/js/controller.js
@@ -482,11 +482,11 @@ CP.updateUI = function (hrmState, nextUiState) {
   }
 
   // Update floor
-  if (hrmState !== undefined && hrmState.variables !== undefined) {
+  if (hrmState !== undefined && this.getLevel().floor !== undefined && hrmState.variables !== undefined) {
     for (var i = 0; i < this.getLevel().floor.rows * this.getLevel().floor.columns; i++) {
-      var displayed = hrmState.variables[i];
-      if (displayed === undefined) {
-        displayed = '';
+      var displayed = '';
+      if (hrmState.variables[i] !== undefined) {
+        displayed = hrmState.variables[i];
       }
 
       $('#floor' + i).text(displayed);
@@ -564,12 +564,13 @@ CP.bindVisuals = function() {
     var level = $(this).val();
     $('#level-instructions').text(HrmLevelData[level].instructions);
     $('#inbox').val(HrmLevelData[level].examples[0].inbox.join(", "));
+    
+    $('#floorState').empty();
+
     if (HrmLevelData[level].floor) {
       $('#variables').val(JSON.stringify(HrmLevelData[level].floor.tiles || {}, null, 2));
 
       // Create floor
-      $('#floorState').empty();
-
       var rows = HrmLevelData[level].floor.rows || 5;
       var columns = HrmLevelData[level].floor.columns || 5;
       var tiles = HrmLevelData[level].floor.tiles;

--- a/web/components/js/controller.js
+++ b/web/components/js/controller.js
@@ -481,6 +481,26 @@ CP.updateUI = function (hrmState, nextUiState) {
     }
   }
 
+  // Update floor
+  if (hrmState !== undefined && hrmState.variables !== undefined) {
+    for (var i = 0; i < this.getLevel().floor.rows * this.getLevel().floor.columns; i++) {
+      var displayed = hrmState.variables[i];
+      if (displayed === undefined) {
+        displayed = '';
+      }
+
+      $('#floor' + i).text(displayed);
+    }
+  } else {
+    $('#floorState td').text('');
+  }
+  // Update hand
+  if (hrmState !== undefined && hrmState.hand !== undefined) {
+    $('#handState').text(hrmState.hand);
+  } else {
+    $('#handState').text('');
+  }
+
   // Update Editor
   var line = hrmState !== undefined ? this.lineFromState(hrmState) : 0;
   this.editor.setCursor(line);
@@ -546,6 +566,32 @@ CP.bindVisuals = function() {
     $('#inbox').val(HrmLevelData[level].examples[0].inbox.join(", "));
     if (HrmLevelData[level].floor) {
       $('#variables').val(JSON.stringify(HrmLevelData[level].floor.tiles || {}, null, 2));
+
+      // Create floor
+      $('#floorState').empty();
+
+      var rows = HrmLevelData[level].floor.rows || 5;
+      var columns = HrmLevelData[level].floor.columns || 5;
+      var tiles = HrmLevelData[level].floor.tiles;
+      var count = 0;
+      for (var row = 0; row < rows; row++) {
+        var rowElement = $('<tr>').appendTo('#floorState');
+        for (var column = 0; column < columns; column++) {
+          var text = '';
+          if ($.isArray(tiles)) {
+            if (tiles.length > count) {
+              text = tiles[count];
+            }
+          } else if (typeof tiles === 'object') {
+            if (tiles.hasOwnProperty(count)) {
+              text = tiles[count];
+            }
+          }
+          
+          $('<td>').attr('id', 'floor' + count).text(text).appendTo(rowElement);
+          count++;
+        }
+      }
     } else {
       $('#variables').val("{}");
     }

--- a/web/hrmfiddle.html
+++ b/web/hrmfiddle.html
@@ -124,9 +124,20 @@ a:
         <ul id="outbox" class="list-unstyled">
         </ul>
       </div>
-      <div class="inputs col-lg-12 col-md-12 col-sm-12">
-      <h4>Floor <small>JSON</small></h4>
-      <textarea id="variables" class="form-control" rows="5"autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">{
+    </div>
+
+    <div class="container-fluid">
+      <div class="floor col-lg-6 col-md-6 col-sm-12">
+        <h4>Floor State<small id="stats"></small></h4>
+        <div id="handState"></div>
+        <table id="floorState">
+          
+        </table>
+      </div>
+
+      <div class="inputs col-lg-6 col-md-6 col-sm-12">
+        <h4>Floor <small>JSON</small></h4>
+        <textarea id="variables" class="form-control" rows="5"autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">{
 "8": 0,
 "9": -3
 }</textarea>


### PR DESCRIPTION
This pull request adds a live floor display which shows the values on the floor, and a hand display showing the value in the hand. It resizes based on the size of the floor for the selected level.

![pull_request_hrmsandbox_floordisplay](https://cloud.githubusercontent.com/assets/1232124/15229270/45612116-185e-11e6-8573-3ab1ba5ab0ad.PNG)